### PR TITLE
Add Ingress to CRD to pass verify-generated test

### DIFF
--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -372,6 +372,7 @@ spec:
                     - OpenShiftRoute
                     - Service
                     - CRD
+                    - Ingress
                     type: string
                 required:
                 - type
@@ -838,6 +839,7 @@ spec:
                     - OpenShiftRoute
                     - Service
                     - CRD
+                    - Ingress
                     type: string
                 required:
                 - type


### PR DESCRIPTION
PR https://github.com/openshift/external-dns-operator/pull/193 fails when CI runs [hack/verify-generated.sh](https://github.com/theckang/external-dns-operator/blob/main/hack/verify-generated.sh).

Adding Ingress to CRD spec fixes this.